### PR TITLE
fix (match) clicking on player links did not display the spinner

### DIFF
--- a/app/containers/PlayerSearch.jsx
+++ b/app/containers/PlayerSearch.jsx
@@ -1,9 +1,6 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { fetchInitialState } from '../reducers';
-
 
 class PlayerSearch extends Component {
   constructor() {
@@ -16,7 +13,6 @@ class PlayerSearch extends Component {
   handleSubmit = (e) => {
     e.preventDefault();
     this.setState({ playerName: '' });
-    this.props.fetchInitialState();
   }
 
   handleChange = (e) => {
@@ -73,7 +69,6 @@ PlayerSearch.propTypes = {
     button_wrapper: PropTypes.string.isRequired,
     go_button: PropTypes.string.isRequired,
   }),
-  fetchInitialState: PropTypes.func.isRequired,
 };
 
 PlayerSearch.defaultProps = {
@@ -87,6 +82,4 @@ PlayerSearch.defaultProps = {
   },
 };
 
-const mapDispatchToProps = { fetchInitialState };
-
-export default connect(null, mapDispatchToProps)(PlayerSearch);
+export default PlayerSearch;

--- a/app/containers/Summoner.jsx
+++ b/app/containers/Summoner.jsx
@@ -6,7 +6,7 @@ import { BasicProfile } from '../components/index';
 import styles from '../styles/LoadingSpinner.css';
 
 // possible because we're exporting from one file
-import { fetchUser, fetchRecent, fetchProfile, fetchChampMastery } from '../reducers';
+import { fetchUser, fetchRecent, fetchProfile, fetchChampMastery, fetchInitialState } from '../reducers';
 
 class Summoner extends Component {
   componentDidMount() {
@@ -67,14 +67,15 @@ const mapDispatchToProps = dispatch => ({
     const { search } = location;
     const params = new URLSearchParams(search);
     const username = params.get('username');
-    dispatch(fetchUser(username))
-      .then((action) => {
-        // eslint-disable-next-line prefer-destructuring
-        user = action.user;
-        return Promise.all([dispatch(fetchProfile(+user.id)), dispatch(fetchRecent(+user.accountId))]);
-      })
-      .then(() => dispatch(fetchChampMastery(+user.id)))
-      .catch(err => console.error(err));
+    Promise.resolve(dispatch(fetchInitialState()))
+      .then(() => dispatch(fetchUser(username))
+        .then((action) => {
+          // eslint-disable-next-line prefer-destructuring
+          user = action.user;
+          return Promise.all([dispatch(fetchProfile(+user.id)), dispatch(fetchRecent(+user.accountId))]);
+        })
+        .then(() => dispatch(fetchChampMastery(+user.id)))
+        .catch(err => console.error(err)));
   },
 });
 


### PR DESCRIPTION
Fixed a bug where clicking on a player from the match did not display the spinner by moving the fetchInitialState into the summoner container.