### PR TITLE
fix: (assets)

### DIFF
--- a/app/components/Matches/PlayerItems.jsx
+++ b/app/components/Matches/PlayerItems.jsx
@@ -16,9 +16,13 @@ const PlayerItems = (props) => {
     <div className={styles.items_container}>
       <img src={`${assets.item}/${ward}.png`} alt={`${ward} icon`} />
       <div className={styles.build}>
-        {itemBuild.map((item, index) =>
-          <img key={index} src={`${assets.item}/${item}.png`} alt={`${item} icon`} />)
-        }
+        {itemBuild.map((item, index) => {
+          if (item === 0) {
+            return <img key={index} src={`/images/items/${item}.png`} alt={`${item} icon`} />;
+          }
+          return <img key={index} src={`${assets.item}/${item}.png`} alt={`${item} icon`} />;
+        })
+      }
       </div>
     </div>
   );

--- a/public/settings.js
+++ b/public/settings.js
@@ -1,5 +1,5 @@
 // static route data for images, easier to update when DDVersion changes
-const ddragonApiRoute = 'http://ddragon.leagueoflegends.com/cdn';
+const ddragonApiRoute = 'https://ddragon.leagueoflegends.com/cdn';
 const latestDDVersion = '7.24.2';
 const url = `${ddragonApiRoute}/${latestDDVersion}/img`;
 

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,8 @@ const { CronJob } = require('cron');
 
 const newsScraper = require('./cronJobs/newsScraper');
 
+newsScraper();
+
 const jobs = new CronJob({
   cronTime: '00 00 */1 * * *',
   onTick() {


### PR DESCRIPTION
Scrape for news immediately when server starts to prevent empty news db.  Fix empty item image not being displayed properly.